### PR TITLE
Change buzzer default pin.

### DIFF
--- a/src/ESP8266RTTTLPlus.cpp
+++ b/src/ESP8266RTTTLPlus.cpp
@@ -69,7 +69,7 @@ static stateEnum currentState = Unready;
 static int currentPitch = 0;
 static long unsigned currentDuration = 0;
 static int currentVolume = maxVolume / 2;
-static int buzzerPin = D1;  // reasonable default?
+static int buzzerPin = 4;  // reasonable default?
 
 static void nextChar (const char **bufferPtr) {
     // Move the buffer pointer along to the next non-whitespace character,


### PR DESCRIPTION
The default value for buzzerPin variable (D1) is not defined for all platform (for example esp8266).